### PR TITLE
DOC: add to README so example works under Python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Usage example
 
    from rejson import Client, Path
 
-   rj = Client(host='localhost', port=6379)
+   rj = Client(host='localhost', port=6379, decode_responses=True)
 
    # Set the key `obj` to some object
    obj = {


### PR DESCRIPTION
**What does this PR implement?**
It adds `decode_responses=True` in the example in README.rst as mentioned in https://github.com/RedisLabs/rejson-py/issues/8#issuecomment-321514267 (which took me too long to find after copy/pasting the example with Python 3.6.5 and rejson-py 0.3.0).